### PR TITLE
Last chance from restoring multilayers direct and MCMC computations

### DIFF
--- a/Molonaviz/src/molonaviz/backend/Compute.py
+++ b/Molonaviz/src/molonaviz/backend/Compute.py
@@ -166,8 +166,6 @@ class Compute(QtCore.QObject):
 
         self.thread.terminate()
         self.thread = QtCore.QThread()
-        self.save_layers_and_params(params)
-        self.update_nb_cells(nb_cells)
 
         self.set_column()  # Updates self.col
         self.direct_runner = ColumnDirectModelRunner(self.col, params, nb_cells)
@@ -203,10 +201,12 @@ class Compute(QtCore.QObject):
         )
         updatePoint.exec()
 
-    def save_layers_and_params(self, data: list[list]):
+    def save_layers_and_params(self, data: list[list], nb_cells : int):
         """
         Save the layers and the last parameters in the database.
         """
+        self.update_nb_cells(nb_cells)
+
         insertlayer = QSqlQuery(self.con)
         insertlayer.prepare(
             "INSERT INTO Layer (Name, Depth, PointKey) VALUES (:Name, :Depth, :PointKey)"
@@ -380,7 +380,6 @@ class Compute(QtCore.QObject):
 
         self.thread.terminate()
         self.thread = QtCore.QThread()
-        self.update_nb_cells(nb_cells)
 
         self.set_column()  # Updates self.col
         self.mcmc_runner = ColumnMCMCRunner(
@@ -411,6 +410,7 @@ class Compute(QtCore.QObject):
         """
         self.save_MCMC_results()
 
+        # TODO What is this function and why there are so much calls to that function in comments
         self.col.compute_solve_transi.reset()
 
         self.thread.quit()
@@ -602,6 +602,7 @@ class Compute(QtCore.QObject):
         self.con.commit()
 
         # Recompute direct model with best parameters.
+        # TODO Not the good place to call direct model after MCMC
         self.col.compute_solve_transi(layers, self.mcmc_runner.nb_cells, verbose=False)
         self.save_direct_model_results(save_dates=False)
 

--- a/Molonaviz/src/molonaviz/backend/Compute.py
+++ b/Molonaviz/src/molonaviz/backend/Compute.py
@@ -214,8 +214,8 @@ class Compute(QtCore.QObject):
         insertlayer.bindValue(":PointKey", self.pointID)
 
         insertparams = QSqlQuery(self.con)
-        insertparams.prepare(f"""INSERT INTO Parameters (Permeability, ThermConduct, Porosity, Capacity, Layer, PointKey)
-                           VALUES (:Permeability, :ThermConduct, :Porosity, :Capacity, :Layer, :PointKey)""")
+        insertparams.prepare(f"""INSERT INTO Parameters (Permeability, Porosity, ThermConduct, Capacity, Layer, PointKey)
+                           VALUES (:Permeability, :Porosity, :ThermConduct, :Capacity, :Layer, :PointKey)""")
         insertparams.bindValue(":PointKey", self.pointID)
 
         self.con.transaction()
@@ -225,8 +225,8 @@ class Compute(QtCore.QObject):
             insertlayer.exec()
 
             insertparams.bindValue(":Permeability", perm)
-            insertparams.bindValue(":ThermConduct", lamb)
             insertparams.bindValue(":Porosity", n)
+            insertparams.bindValue(":ThermConduct", lamb)
             insertparams.bindValue(":Capacity", rho)
             insertparams.bindValue(":Layer", insertlayer.lastInsertId())
             insertparams.exec()
@@ -557,14 +557,14 @@ class Compute(QtCore.QObject):
         insertlayer.bindValue(":PointKey", self.pointID)
         insertparams = QSqlQuery(self.con)
         insertparams.prepare(
-            f"""INSERT INTO BestParameters (Permeability, ThermConduct, Porosity, Capacity, Layer, PointKey)
-                           VALUES (:Permeability, :ThermConduct, :Porosity, :Capacity, :Layer, :PointKey)"""
+            f"""INSERT INTO BestParameters (Permeability, Porosity, ThermConduct, Capacity, Layer, PointKey)
+                           VALUES (:Permeability, :Porosity, :ThermConduct, :Capacity, :Layer, :PointKey)"""
         )
         insertparams.bindValue(":PointKey", self.pointID)
         insertdistribution = QSqlQuery(self.con)
         insertdistribution.prepare(
-            """INSERT INTO ParametersDistribution (Permeability, ThermConduct, Porosity, HeatCapacity, Layer, PointKey)
-                VALUES (:Permeability, :ThermConduct,  :Porosity, :HeatCapacity, :Layer, :PointKey)"""
+            """INSERT INTO ParametersDistribution (Permeability, Porosity, ThermConduct, HeatCapacity, Layer, PointKey)
+                VALUES (:Permeability, :Porosity, :ThermConduct, :HeatCapacity, :Layer, :PointKey)"""
         )
         insertdistribution.bindValue(":PointKey", self.pointID)
 
@@ -583,8 +583,8 @@ class Compute(QtCore.QObject):
             layerID = insertlayer.lastInsertId()
 
             insertparams.bindValue(":Permeability", perm)
-            insertparams.bindValue(":ThermConduct", lambda_s)
             insertparams.bindValue(":Porosity", poro)
+            insertparams.bindValue(":ThermConduct", lambda_s)
             insertparams.bindValue(":Capacity", rhos_cs)
             insertparams.bindValue(":Layer", layerID)
             insertparams.exec()
@@ -593,8 +593,8 @@ class Compute(QtCore.QObject):
             for params in all_params_layer:
                 # Convert everything to float as the parameters are of type np.float
                 insertdistribution.bindValue(":Permeability", float(params[0]))
-                insertdistribution.bindValue(":ThermConduct", float(params[2]))
                 insertdistribution.bindValue(":Porosity", float(params[1]))
+                insertdistribution.bindValue(":ThermConduct", float(params[2]))
                 insertdistribution.bindValue(":HeatCapacity", float(params[3]))
                 insertdistribution.bindValue(":Layer", layerID)
                 insertdistribution.exec()

--- a/Molonaviz/src/molonaviz/backend/GraphsModels.py
+++ b/Molonaviz/src/molonaviz/backend/GraphsModels.py
@@ -273,12 +273,12 @@ class ParamsDistributionModel(MoloModel):
         try:
             while self.queries[0].next():
                 self.log10k.append(self.queries[0].value(0))
-                self.conductivity.append(self.queries[0].value(1))
-                self.porosity.append(self.queries[0].value(2))
+                self.porosity.append(self.queries[0].value(1))
+                self.conductivity.append(self.queries[0].value(2))
                 self.capacity.append(self.queries[0].value(3))
             self.log10k = np.array(self.log10k)
-            self.conductivity = np.array(self.conductivity)
             self.porosity = np.array(self.porosity)
+            self.conductivity = np.array(self.conductivity)
             self.capacity = np.array(self.capacity)
         except Exception:
             #Empty query or invalid query: then revert any changes done. The model is empty: nothing will be displayed.

--- a/Molonaviz/src/molonaviz/backend/LabEquipementManager.py
+++ b/Molonaviz/src/molonaviz/backend/LabEquipementManager.py
@@ -15,7 +15,7 @@ class LabEquipementManager:
         self.shaftModel = ShaftsModel([])
 
         selectLabID = self.build_select_lab_id(labName)
-        selectLabID.exec()
+        if (not selectLabID.exec()) : print(selectLabID.lastError())
         selectLabID.next()
         self.labID = selectLabID.value(0)
 
@@ -35,7 +35,7 @@ class LabEquipementManager:
         """
         select_psensors = self.build_select_psensors()
         psensors = []
-        select_psensors.exec()
+        if (not select_psensors.exec()) : print(select_psensors.lastError())
         while select_psensors.next():
             psensors.append(select_psensors.value(0))
         return psensors
@@ -47,7 +47,7 @@ class LabEquipementManager:
         """
         select_shafts = self.build_select_shafts()
         shafts = []
-        select_shafts.exec()
+        if (not select_shafts.exec()) : print(select_shafts.lastError())
         while select_shafts.next():
             shafts.append(select_shafts.value(0))
         return shafts

--- a/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
+++ b/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
@@ -322,6 +322,7 @@ class SPointCoordinator:
         deleteTableQuery.exec(f'DELETE FROM RMSE WHERE PointKey=(SELECT Point.ID FROM Point WHERE Point.ID ={self.pointID})')
         deleteTableQuery.exec(f'DELETE FROM TemperatureAndHeatFlows WHERE PointKey=(SELECT Point.ID FROM Point WHERE Point.ID  = {self.pointID})')
         deleteTableQuery.exec(f'DELETE FROM ParametersDistribution WHERE ParametersDistribution.PointKey=(SELECT Point.ID FROM Point WHERE Point.ID = {self.pointID})')
+        deleteTableQuery.exec(f'DELETE FROM Parameters WHERE Parameters.PointKey=(SELECT Point.ID FROM Point WHERE Point.ID = {self.pointID})')
         deleteTableQuery.exec(f'DELETE FROM BestParameters WHERE BestParameters.PointKey=(SELECT Point.ID FROM Point WHERE Point.ID = {self.pointID})')
         deleteTableQuery.exec(f'DELETE FROM Quantiles WHERE Quantiles.PointKey=(SELECT Point.ID FROM Point WHERE Point.ID = {self.pointID})')
         deleteTableQuery.exec(f'DELETE FROM Depth WHERE Depth.PointKey=(SELECT Point.ID FROM Point WHERE Point.ID = {self.pointID})')

--- a/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
+++ b/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
@@ -495,7 +495,7 @@ class SPointCoordinator:
         """
         query = QSqlQuery(self.con)
         query.prepare("""
-            SELECT Niter, Delta, Nchains,NCR, C, Cstar, Kmin, Kmax, Ksigma,PorosityMin, PorosityMax, PorositySigma,
+            SELECT Niter, Delta, Nchains, NCR, C, Cstar, Kmin, Kmax, Ksigma,PorosityMin, PorosityMax, PorositySigma,
             TcondMin, TcondMax, TcondSigma, TcapMin, TcapMax, TcapSigma, Remanence , tresh , nb_sous_ech_iter ,
             nb_sous_ech_space , nb_sous_ech_time ,  Quantiles FROM InputMCMC
         """)

--- a/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
+++ b/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
@@ -428,7 +428,7 @@ class SPointCoordinator:
         """
         query = QSqlQuery(self.con)
         query.prepare(f"""
-            SELECT BestParameters.Permeability, BestParameters.ThermConduct, BestParameters.Porosity, BestParameters.Capacity FROM BestParameters
+            SELECT BestParameters.Permeability, BestParameters.Porosity, BestParameters.ThermConduct, BestParameters.Capacity FROM BestParameters
             JOIN Layer ON BestParameters.Layer = Layer.ID
             JOIN Point
             ON BestParameters.PointKey = Point.ID
@@ -443,7 +443,7 @@ class SPointCoordinator:
         """
         query = QSqlQuery(self.con)
         query.prepare(f"""
-            SELECT Parameters.Permeability, Parameters.ThermConduct, Parameters.Porosity, Parameters.Capacity FROM Parameters
+            SELECT Parameters.Permeability, Parameters.Porosity, Parameters.ThermConduct, Parameters.Capacity FROM Parameters
             JOIN Layer ON Parameters.Layer = Layer.ID
             JOIN Point
             ON Parameters.PointKey = Point.ID
@@ -458,7 +458,7 @@ class SPointCoordinator:
         """
         query = QSqlQuery(self.con)
         query.prepare(f"""
-            SELECT Permeability, ThermConduct, Porosity, HeatCapacity FROM ParametersDistribution
+            SELECT Permeability, Porosity, ThermConduct, HeatCapacity FROM ParametersDistribution
             JOIN Point
             ON ParametersDistribution.PointKey = Point.ID
             JOIN Layer

--- a/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
+++ b/Molonaviz/src/molonaviz/backend/SPointCoordinator.py
@@ -84,7 +84,7 @@ class SPointCoordinator:
 
     def get_best_params_model(self, layer : float):
         """
-        Given a layer (identified by its depth), return the associated best parameters.
+        Given a layer (identified by its depth (in m)), return the associated best parameters.
         """
         select_params = self.build_best_params_query(layer)
         select_params.exec()
@@ -94,7 +94,7 @@ class SPointCoordinator:
     
     def get_params_model(self, layer : float):
         """
-        Given a layer (identified by its depth), return the associated best parameters.
+        Given a layer (identified by its depth (in m)), return the associated best parameters.
         """
         select_params = self.build_params_query(layer)
         select_params.exec()
@@ -717,7 +717,7 @@ class SPointCoordinator:
 
     def build_max_depth(self):
         """
-        Build and return a query giving the total depth for the sampling point with the ID samplingPointID.
+        Build and return a query giving the total depth (in m) for the sampling point with the ID samplingPointID.
         """
         shaft_depth = QSqlQuery(self.con)
         shaft_depth.prepare(f"""

--- a/Molonaviz/src/molonaviz/backend/SamplingPointManager.py
+++ b/Molonaviz/src/molonaviz/backend/SamplingPointManager.py
@@ -38,7 +38,7 @@ class SamplingPointManager:
         self.spointModel = SamplingPointModel([])
 
         select_study_id = self.build_study_id(studyName)
-        select_study_id.exec()
+        if (not select_study_id.exec()) : print(select_study_id.lastError())
         select_study_id.next()
         self.studyID = select_study_id.value(0)
         self.studyName = studyName
@@ -53,7 +53,7 @@ class SamplingPointManager:
         """
         select_spoints = self.build_select_spoints()
         spoints = []
-        select_spoints.exec()
+        if (not select_spoints.exec()) : print(select_spoints.lastError())
         while select_spoints.next():
             spoints.append(select_spoints.value(0))
         return spoints
@@ -63,7 +63,7 @@ class SamplingPointManager:
         Return a SamplingPoint object representing the sampling point with name spointName.
         """
         select_spoints = self.build_select_spoints(spointName)
-        select_spoints.exec()
+        if (not select_spoints.exec()) : print(select_spoints.lastError())
         select_spoints.next()
         return SamplingPoint(select_spoints.value(0), select_spoints.value(1),select_spoints.value(2), select_spoints.value(3), select_spoints.value(4))
 
@@ -99,7 +99,7 @@ class SamplingPointManager:
             insertRawPress.bindValue(":Date", row[1])
             insertRawPress.bindValue(":TempBed", row[3])
             insertRawPress.bindValue(":Voltage", row[2])
-            insertRawPress.exec()
+            if (not insertRawPress.exec()) : print(insertRawPress.lastError())
         self.con.commit()
 
         #Temperature records
@@ -112,7 +112,7 @@ class SamplingPointManager:
             insertRawTemp.bindValue(":Temp2", row[3])
             insertRawTemp.bindValue(":Temp3", row[4])
             insertRawTemp.bindValue(":Temp4", row[5])
-            insertRawTemp.exec()
+            if (not insertRawTemp.exec()) : print(insertRawTemp.lastError())
         self.con.commit()
 
     def insert_new_point(self, pointName : str, psensorName : str, shaftName :str, noticefile : str, configfile : str, infoDF : pd.DataFrame,):
@@ -139,12 +139,12 @@ class SamplingPointManager:
         insertPoint.bindValue(":RiverBed", infoDF.iloc[5].at[1])
         #Add the shaft's ID
         select_shaft_id = self.build_shaft_id(shaftName)
-        select_shaft_id.exec()
+        if (not select_shaft_id.exec()) : print(select_shaft_id.lastError())
         select_shaft_id.next()
         insertPoint.bindValue(":Shaft", select_shaft_id.value(0))
         #Add the pressure sensor's ID
         select_psensor_id = self.build_psensor_id(psensorName)
-        select_psensor_id.exec()
+        if (not select_psensor_id.exec()) : print(select_psensor_id.lastError())
         select_psensor_id.next()
         insertPoint.bindValue(":PressureSensor", select_psensor_id.value(0))
         #Path to the configuration file
@@ -154,8 +154,8 @@ class SamplingPointManager:
         #Default cleanup script
         cleanupScriptPath = os.path.join(os.path.dirname(self.con.databaseName()),"Scripts", "sample_text.txt")
         insertPoint.bindValue(":CleanupScript", cleanupScriptPath)
-
-        insertPoint.exec()
+        if (not insertPoint.exec()) : print(insertPoint.lastError())
+        
         return insertPoint.lastInsertId()
 
     def build_study_id(self, studyName : str):

--- a/Molonaviz/src/molonaviz/backend/StudyAndLabManager.py
+++ b/Molonaviz/src/molonaviz/backend/StudyAndLabManager.py
@@ -28,14 +28,14 @@ class StudyAndLabManager:
         Create a new study with the name studyName attached to the laboratory called labName. The names must be valid (ie studyName is unique, and there is a unique laboratory called labName).
         """
         selectLabID = self.build_lab_id(labName)
-        selectLabID.exec()
+        if (not selectLabID.exec()) : print(selectLabID.lastError())
         selectLabID.next()
         labID = selectLabID.value(0)
 
         insertStudy = self.build_insert_study()
         insertStudy.bindValue(":Name",studyName)
         insertStudy.bindValue(":Labo",labID)
-        insertStudy.exec()
+        if (not insertStudy.exec()) : print(insertStudy.lastError())
         print(f"The study {studyName} has been added to the database.")
 
     def is_study_in_database(self, studyName : str):
@@ -44,7 +44,7 @@ class StudyAndLabManager:
         Return True if a study with the name studyName is in the database.
         """
         similar_studies = self.build_similar_studies(studyName)
-        similar_studies.exec()
+        if (not similar_studies.exec()) : print(similar_studies.lastError())
         if similar_studies.next():
             return True
         return False
@@ -56,7 +56,7 @@ class StudyAndLabManager:
         """
         labs_query = self.build_select_labs(studyName)
         labs = []
-        labs_query.exec()
+        if (not labs_query.exec()) : print(labs_query.lastError())
         while labs_query.next():
             labs.append(labs_query.value(0))
         return labs
@@ -68,7 +68,7 @@ class StudyAndLabManager:
         """
         studies_query = self.build_select_studies()
         studies = []
-        studies_query.exec()
+        if (not studies_query.exec()) : print(studies_query.lastError())
         while studies_query.next():
             studies.append(studies_query.value(0))
         return studies
@@ -79,7 +79,7 @@ class StudyAndLabManager:
         For now, this means checking there is no laboratory with the same name in the database.
         """
         similar_lab = self.build_similar_lab(labName)
-        similar_lab.exec()
+        if (not similar_lab.exec()) : print(similar_lab.lastError())
         if similar_lab.next():
             return False
         return True
@@ -90,7 +90,7 @@ class StudyAndLabManager:
         Return the ID of the newly inserted laboratory.
         """
         insert_lab = self.build_insert_lab(labName)
-        insert_lab.exec()
+        if (not insert_lab.exec()) : print(insert_lab.lastError())
         print(f"The lab {labName} has been added to the database.")
         return insert_lab.lastInsertId()
 
@@ -115,7 +115,7 @@ class StudyAndLabManager:
             insertQuery.bindValue(":ManuRef",ref)
             insertQuery.bindValue(":Error",sigma)
             insertQuery.bindValue(":Labo",labID)
-            insertQuery.exec()
+            if (not insertQuery.exec()) : print(insertQuery.lastError())
         print("The thermometers have been added to the database.") #TODO: Maybe a little check before asserting this?
 
         insertPsensor = self.build_insert_psensor()
@@ -129,7 +129,7 @@ class StudyAndLabManager:
             sigma = float(df.iloc[6].at[1].replace(',','.'))
             thermo_name = df.iloc[7].at[1]
             select_thermo = self.build_thermo_id(labID, thermo_name)
-            select_thermo.exec()
+            if (not select_thermo.exec()) : print(select_thermo.lastError())
             select_thermo.next()
             thermo_model = select_thermo.value(0)
 
@@ -142,7 +142,7 @@ class StudyAndLabManager:
             insertPsensor.bindValue(":Error",sigma)
             insertPsensor.bindValue(":ThermoModel",thermo_model)
             insertPsensor.bindValue(":Labo",labID)
-            insertPsensor.exec()
+            if (not insertPsensor.exec()) : print(insertPsensor.lastError())
         print("The pressure sensors have been added to the database.") #TODO: Maybe a little check before asserting this?
 
         insertShaft = self.build_insert_shaft()
@@ -152,7 +152,7 @@ class StudyAndLabManager:
             tSensorName = df.iloc[2].at[1]
             depths = literal_eval(df.iloc[3].at[1]) #This is now a list
             select_thermo = self.build_thermo_id(labID, tSensorName)
-            select_thermo.exec()
+            if (not select_thermo.exec()) : print(select_thermo.lastError())
             select_thermo.next()
             thermo_model = select_thermo.value(0)
 
@@ -164,7 +164,7 @@ class StudyAndLabManager:
             insertShaft.bindValue(":Depth4",depths[3])
             insertShaft.bindValue(":ThermoModel",thermo_model)
             insertShaft.bindValue(":Labo",labID)
-            insertShaft.exec()
+            if (not insertShaft.exec()) : print(insertShaft.lastError())
         print("The shafts have been added to the database.")#TODO: Maybe a little check before asserting this?
 
     def build_similar_lab(self, labName : str):

--- a/Molonaviz/src/molonaviz/docs/ERD_structure.sql
+++ b/Molonaviz/src/molonaviz/docs/ERD_structure.sql
@@ -2,10 +2,10 @@ PRAGMA foreign_keys = off;
 BEGIN TRANSACTION;
 
 -- Table: BestParameters
-CREATE TABLE BestParameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, ThermConduct REAL, Porosity REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
+CREATE TABLE BestParameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, Porosity REAL, ThermConduct REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
 
 -- Table: BestParameters
-CREATE TABLE Parameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, ThermConduct REAL, Porosity REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
+CREATE TABLE Parameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, Porosity REAL, ThermConduct REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
 
 -- Table: CleanedMeasures
 CREATE TABLE CleanedMeasures (ID INTEGER PRIMARY KEY AUTOINCREMENT, Date INTEGER REFERENCES Date (ID), TempBed REAL NOT NULL, Temp1 REAL NOT NULL, Temp2 REAL NOT NULL, Temp3 REAL NOT NULL, Temp4 REAL NOT NULL, Pressure REAL NOT NULL, PointKey INTEGER REFERENCES Point (ID));
@@ -23,7 +23,7 @@ CREATE TABLE Labo (ID INTEGER PRIMARY KEY AUTOINCREMENT, Name VARCHAR NOT NULL U
 CREATE TABLE Layer (ID INTEGER PRIMARY KEY AUTOINCREMENT, Name VARCHAR, Depth REAL, PointKey REFERENCES Point (ID));
 
 -- Table: ParametersDistribution
-CREATE TABLE ParametersDistribution (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, ThermConduct REAL, Porosity REAL, HeatCapacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
+CREATE TABLE ParametersDistribution (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, Porosity REAL, ThermConduct REAL, HeatCapacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
 
 -- Table: Point
 CREATE TABLE Point (ID INTEGER PRIMARY KEY AUTOINCREMENT, SamplingPoint INTEGER REFERENCES SamplingPoint (ID), IncertK REAL, IncertLambda REAL, DiscretStep INTEGER, IncertRho REAL, TempUncertainty REAL, IncertPressure REAL);

--- a/Molonaviz/src/molonaviz/docs/ERD_structure.sql
+++ b/Molonaviz/src/molonaviz/docs/ERD_structure.sql
@@ -4,8 +4,11 @@ BEGIN TRANSACTION;
 -- Table: BestParameters
 CREATE TABLE BestParameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, Porosity REAL, ThermConduct REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
 
--- Table: BestParameters
+-- Table: Parameters
 CREATE TABLE Parameters (ID INTEGER PRIMARY KEY AUTOINCREMENT, Permeability REAL, Porosity REAL, ThermConduct REAL, Capacity REAL, Layer INTEGER REFERENCES Layer (ID), PointKey INTEGER REFERENCES Point (ID));
+
+-- Table: InputMCMC
+CREATE TABLE InputMCMC (ID INTEGER PRIMARY KEY AUTOINCREMENT, Niter INT, Delta INT, Nchains INT, NCR INT, C REAL, Cstar REAL, Kmin REAL, Kmax REAL, Ksigma REAL, PorosityMin REAL, PorosityMax REAL, PorositySigma REAL, TcondMin REAL, TcondMax REAL, TcondSigma REAL, TcapMin REAL, TcapMax REAL, TcapSigma REAL, Remanence REAL, tresh REAL, nb_sous_ech_iter INT, nb_sous_ech_space iNT, nb_sous_ech_time INT, Quantiles TEXT, PointKey INTEGER REFERENCES Point (ID));
 
 -- Table: CleanedMeasures
 CREATE TABLE CleanedMeasures (ID INTEGER PRIMARY KEY AUTOINCREMENT, Date INTEGER REFERENCES Date (ID), TempBed REAL NOT NULL, Temp1 REAL NOT NULL, Temp2 REAL NOT NULL, Temp3 REAL NOT NULL, Temp4 REAL NOT NULL, Pressure REAL NOT NULL, PointKey INTEGER REFERENCES Point (ID));

--- a/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
+++ b/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
@@ -433,15 +433,13 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
             self.coordinator.delete_computations()
             if dlg.computationIsMCMC():
                 #MCMC
-                nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time = dlg.getInputMCMC()
-                self.computeEngine.compute_MCMC(nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time, thresh)
-                dlg.save_input_MCMC()
+                paramsMCMC = dlg.getInputMCMC()
+                self.computeEngine.compute_MCMC(paramsMCMC)
 
             else:
                 #Direct Model
                 params, nb_cells = dlg.getInputDirectModel()
                 self.computeEngine.compute_direct_model(params, nb_cells)
-                dlg.SaveInput()
 
             self.handleComputationsButtons()
 

--- a/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
+++ b/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
@@ -427,7 +427,7 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
         Launch the computation of the direct model or the MCMC model, depending on the user's choice.
         '''
 
-        dlg = DialogCompute(self.coordinator.max_depth(), self.coordinator, self.computeEngine)
+        dlg = DialogCompute(self.coordinator.max_depth(), self.coordinator, self.computeEngine, self.statusNightmode)
         res = dlg.exec()
         if res == QtWidgets.QDialog.Accepted:
             self.coordinator.delete_computations()
@@ -437,6 +437,7 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
                 self.computeEngine.compute_MCMC(nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time, thresh)
             else:
                 #Direct Model
+                dlg.SaveInput()
                 params, nb_cells = dlg.getInputDirectModel()
                 self.computeEngine.compute_direct_model(params, nb_cells)
 

--- a/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
+++ b/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
@@ -79,7 +79,7 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
 
 
         # Link every button to their function
-        self.comboBoxSelectLayer.textActivated.connect(self.changeDisplayedParams2)
+        self.comboBoxSelectLayer.textActivated.connect(self.changeDisplayedParams)
         self.radioButtonTherm1.clicked.connect(self.refreshTempDepthView)
         self.radioButtonTherm2.clicked.connect(self.refreshTempDepthView)
         self.radioButtonTherm3.clicked.connect(self.refreshTempDepthView)
@@ -232,13 +232,13 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
             self.comboBoxSelectLayer.addItem(str(layer))
         if len(layers) > 0:
             # By default, show the parameters associated with the first layer.
-            self.changeDisplayedParams2(layers[0])
+            self.changeDisplayedParams(layers[0])
 
-    def changeDisplayedParams2(self, layer : float):
+    def changeDisplayedParams(self, layer : float):
         """
         Display in the table view the parameters corresponding to the given layer, and update histograms.
         """
-        self.paramsModel = self.coordinator.get_best_params_model(layer)
+        #TODO : show parameters for the current layer?
         #Resize the table view so it looks pretty
         self.coordinator.refresh_params_distr(layer)
 
@@ -435,11 +435,13 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
                 #MCMC
                 nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time = dlg.getInputMCMC()
                 self.computeEngine.compute_MCMC(nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time, thresh)
+                dlg.save_input_MCMC()
+
             else:
                 #Direct Model
-                dlg.SaveInput()
                 params, nb_cells = dlg.getInputDirectModel()
                 self.computeEngine.compute_direct_model(params, nb_cells)
+                dlg.SaveInput()
 
             self.handleComputationsButtons()
 

--- a/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
+++ b/Molonaviz/src/molonaviz/frontend/SamplingPointViewer.py
@@ -7,7 +7,7 @@ from ..interactions.InnerMessages import ComputationsState
 from ..backend.SPointCoordinator import SPointCoordinator
 from ..backend.Compute import Compute
 
-from .GraphViews import PressureView, TemperatureView,UmbrellaView,TempDepthView,TempMapView,AdvectiveFlowView, ConductiveFlowView, TotalFlowView, WaterFluxView, Log10KView, ConductivityView, PorosityView, CapacityView
+from .GraphViews import PressureView, TemperatureView,UmbrellaView,TempDepthView,TempMapView,AdvectiveFlowView, ConductiveFlowView, TotalFlowView, WaterFluxView, Log10KView, PorosityView, ConductivityView, CapacityView
 from .dialogExportCleanedMeasures import DialogExportCleanedMeasures
 from .dialogConfirm import DialogConfirm
 from .dialogsCleanup import DialogCleanup
@@ -65,8 +65,8 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
         self.depth_view = TempDepthView(self.coordinator.get_temp_model(), self.coordinator.get_temp_map_model(), self.coordinator)
         paramsDistrModel = self.coordinator.get_params_distr_model()
         self.logk_view = Log10KView(paramsDistrModel)
-        self.conductivity_view = ConductivityView(paramsDistrModel)
         self.porosity_view = PorosityView(paramsDistrModel)
+        self.conductivity_view = ConductivityView(paramsDistrModel)
         self.capacity_view = CapacityView(paramsDistrModel)
 
         self.layoutsRules = self.initialiseLayoutsRules()
@@ -120,8 +120,8 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
                             self.botLeftVLayout : (self.umbrella_view, default_message),
                             self.botRightVLayout : (self.tempmap_view, default_message),
                             self.log10KVBox : (self.logk_view, default_message),
-                            self.conductivityVBox : (self.conductivity_view, default_message),
                             self.porosityVBox : (self.porosity_view, default_message),
+                            self.conductivityVBox : (self.conductivity_view, default_message),
                             self.capacityVBox : (self.capacity_view, default_message)}
         return layoutsRules
 
@@ -177,11 +177,11 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
         self.logk_view.updateBins(bins)
         self.logk_view.onUpdate()
 
-        self.conductivity_view.updateBins(bins)
-        self.conductivity_view.onUpdate()
-
         self.porosity_view.updateBins(bins)
         self.porosity_view.onUpdate()
+
+        self.conductivity_view.updateBins(bins)
+        self.conductivity_view.onUpdate()
 
         self.capacity_view.updateBins(bins)
         self.capacity_view.onUpdate()
@@ -355,7 +355,7 @@ class SamplingPointViewer(QtWidgets.QWidget, From_SamplingPointViewer):
 
         This function takes into account checkBoxRawData's status and the computation type given by the backend
         """
-        MCMC_layouts = [self.log10KVBox, self.conductivityVBox, self.porosityVBox, self.capacityVBox]
+        MCMC_layouts = [self.log10KVBox, self.porosityVBox, self.conductivityVBox, self.capacityVBox]
         direct_model_layouts = [self.waterFluxVBox, self.advectiveFluxVBox, self.totalFluxVBox, self.conductiveFluxVBox, self.topRightVLayout, self.botLeftVLayout, self.botRightVLayout]
         cleaned_measures_layouts = [self.pressVBox, self.tempVBox]
         all_layouts =  cleaned_measures_layouts + direct_model_layouts + MCMC_layouts

--- a/Molonaviz/src/molonaviz/frontend/cleanupCanvases.py
+++ b/Molonaviz/src/molonaviz/frontend/cleanupCanvases.py
@@ -105,10 +105,11 @@ class SelectCanvas(CompareCanvas):
     def __init__(self, reference_data: pd.DataFrame, field):
         super().__init__(reference_data)
 
-        self.field = field# The only field which will be shown
+        self.field = field # The only field which will be shown
         self.x = self.reference_data["Date"]
         self.y = self.reference_data[self.field]
         self.last_selection = createEmptyDf()
+        self.selected_data = createEmptyDf()
 
         self.selector = RectangleSelector(self.axes, self.selectPoints, useblit=True)
 
@@ -116,6 +117,8 @@ class SelectCanvas(CompareCanvas):
         var_plotted = self.reference_data.copy(deep = True)
         mask = self.inside(event1, event2)
         self.last_selection = var_plotted[mask]
+        self.selected_data = pd.concat([self.selected_data, self.last_selection], axis = 0)  # multiselection (TL)
+        self.selected_data.drop_duplicates(inplace = True)
         self.plotData(self.field)
 
     def inside(self, event1, event2):
@@ -150,6 +153,7 @@ class SelectCanvas(CompareCanvas):
 
     def reset(self):
         self.last_selection = self.createEmptyDf()
+        self.selected_data = self.createEmptyDf()
 
     def getSelectedPoints(self):
-        return self.last_selection
+        return self.selected_data

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -40,6 +40,8 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
                     valeur = self.params[row].index(0, col).data()
                     self.input[row].append(valeur)
 
+        self.inputMCMC = spointcoordinator.get_params_MCMC_model()
+
         #Prevent the user from writing something in the spin box.
         self.spinBoxNLayersDirect.lineEdit().setReadOnly(True)
         #Resize the table's headers
@@ -47,6 +49,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
 
         self.spinBoxNLayersDirect.valueChanged.connect(self.updateNBLayers)
         self.pushButtonRestoreDefault.clicked.connect(self.setDefaultValues)
+        self.pushButtonRestoreDefault.clicked.connect(self.setDefaultValuesMCMC)
         self.pushButtonRun.clicked.connect(self.run)
 
         self.groupBoxMCMC.setChecked(False)
@@ -55,6 +58,11 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
             self.setDefaultValues()
         else:
             self.InitValues()
+
+        if self.inputMCMC == []:
+            self.setDefaultValuesMCMC()
+        else:
+            self.InitValuesMCMC()
 
     def InitValues(self):
         """
@@ -73,45 +81,47 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
             self.tableWidget.setItem(i, 3, QTableWidgetItem(str(self.input[i][2])))
             self.tableWidget.setItem(i, 4, QTableWidgetItem(str(self.input[i][3])))
 
-        #MCMC
-        self.lineEditChains.setText("10")
-        self.lineEditDelta.setText("3")
-        self.lineEditncr.setText("3")
-        self.lineEditc.setText("0.1")
-        self.lineEditcstar.setText("1e-6")
-        self.lineEditPersi.setText("1")
-        self.lineEditThresh.setText("1.2")
-
-        self.lineEditIterStep.setText("10")
-        self.lineEditSpaceStep.setText("1")
-        self.lineEditTimeStep.setText("1")
-
+    def InitValuesMCMC(self):
 
         #MCMC
-        self.lineEditMaxIterMCMC.setText("50")
-        self.lineEditKMin.setText("11")
-        self.lineEditKMax.setText("15")
-        self.lineEditmoinslog10IntrinKSigma.setText("0.01")
+        self.lineEditMaxIterMCMC.setText(str(self.inputMCMC[0]))
 
-        self.lineEditPorosityMin.setText("0.01")
-        self.lineEditPorosityMax.setText("0.25")
-        self.lineEditPorositySigma.setText("0.01")
+        self.lineEditChains.setText(str(self.inputMCMC[1]))
+        self.lineEditDelta.setText(str(self.inputMCMC[2]))
+        self.lineEditncr.setText(str(self.inputMCMC[3]))
+        self.lineEditc.setText(str(self.inputMCMC[4]))
+        self.lineEditcstar.setText(str(self.inputMCMC[5]))
 
-        self.lineEditThermalConductivityMin.setText("1")
-        self.lineEditThermalConductivityMax.setText("5")
-        self.lineEditThermalConductivitySigma.setText("0.05")
+        self.lineEditKMin.setText(str(self.inputMCMC[6]))
+        self.lineEditKMax.setText(str(self.inputMCMC[7]))
+        self.lineEditmoinslog10IntrinKSigma.setText(str(self.inputMCMC[8]))
 
-        self.lineEditThermalCapacityMin.setText("1e6")
-        self.lineEditThermalCapacityMax.setText("1e7")
-        self.lineEditThermalCapacitySigma.setText("100")
+        self.lineEditPorosityMin.setText(str(self.inputMCMC[9]))
+        self.lineEditPorosityMax.setText(str(self.inputMCMC[10]))
+        self.lineEditPorositySigma.setText(str(self.inputMCMC[11]))
 
-        self.lineEditQuantiles.setText("0.05,0.5,0.95")
+        self.lineEditThermalConductivityMin.setText(str(self.inputMCMC[12]))
+        self.lineEditThermalConductivityMax.setText(str(self.inputMCMC[13]))
+        self.lineEditThermalConductivitySigma.setText(str(self.inputMCMC[14]))
+
+        self.lineEditThermalCapacityMin.setText(str(self.inputMCMC[15]))
+        self.lineEditThermalCapacityMax.setText(str(self.inputMCMC[16]))
+        self.lineEditThermalCapacitySigma.setText(str(self.inputMCMC[17]))
+
+        self.lineEditPersi.setText(str(self.inputMCMC[18]))
+        self.lineEditThresh.setText(str(self.inputMCMC[19]))
+
+        self.lineEditIterStep.setText(str(self.inputMCMC[20]))
+        self.lineEditSpaceStep.setText(str(self.inputMCMC[21]))
+        self.lineEditTimeStep.setText(str(self.inputMCMC[22]))
+
+        self.lineEditQuantiles.setText(str(self.inputMCMC[23]))
 
 
     def SaveInput(self):
 
         """
-        Save the layers and the last parameters in the database.
+        Save the layers, the parameters and the MCMC parameters in the database.
         """
         nb_cells = self.spinBoxNCellsDirect.value()
         nb_layers = self.spinBoxNLayersDirect.value()
@@ -151,6 +161,8 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.tableWidget.setItem(0, 3, QTableWidgetItem(str(self.input[0][2])))
         self.tableWidget.setItem(0, 4, QTableWidgetItem(str(self.input[0][3])))
 
+    def setDefaultValuesMCMC(self):
+
         #MCMC
         self.lineEditMaxIterMCMC.setText("50")
 
@@ -178,7 +190,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.lineEditThermalConductivityMax.setText("5")
         self.lineEditThermalConductivitySigma.setText("0.05")
 
-        self.lineEditThermalCapacityMin.setText("1000")
+        self.lineEditThermalCapacityMin.setText("1e6")
         self.lineEditThermalCapacityMax.setText("1e7")
         self.lineEditThermalCapacitySigma.setText("100")
 
@@ -234,6 +246,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         thermconduct = []
         thermcap = []
 
+        # Same format as ColumnMCMCRunner.get_last_best_params
         for i in range (nb_layers):
             depths.append(float(self.tableWidget.item(i, 0).text()))
             permeability.append(float(self.tableWidget.item(i, 1).text()))
@@ -301,6 +314,47 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         quantiles = [float(quantile) for quantile in quantiles]
 
         return nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar,  remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time
+
+    def save_input_MCMC(self):
+        nb_cells = self.spinBoxNCellsDirect.value()
+
+        nb_iter = int(self.lineEditMaxIterMCMC.text())
+        nb_chains = int(self.lineEditChains.text())
+        delta = float(self.lineEditDelta.text())
+        ncr = float(self.lineEditncr.text())
+        c = float(self.lineEditc.text())
+        cstar = float(self.lineEditcstar.text())
+
+        #The user's input (in MCMC panel) is not a permeability but a -log10(permeability)
+        moins10logKmin = float(self.lineEditKMin.text())
+        moins10logKmax = float(self.lineEditKMax.text())
+        moins10logKsigma = float(self.lineEditmoinslog10IntrinKSigma.text())
+
+        nmin = float(self.lineEditPorosityMin.text())
+        nmax = float(self.lineEditPorosityMax.text())
+        nsigma = float(self.lineEditPorositySigma.text())
+
+        lambda_s_min = float(self.lineEditThermalConductivityMin.text())
+        lambda_s_max = float(self.lineEditThermalConductivityMax.text())
+        lambda_s_sigma = float(self.lineEditThermalConductivitySigma.text())
+
+        rhos_cs_min = float(self.lineEditThermalCapacityMin.text())
+        rhos_cs_max = float(self.lineEditThermalCapacityMax.text())
+        rhos_cs_sigma = float(self.lineEditThermalCapacitySigma.text())
+
+        remanence = float(self.lineEditPersi.text())
+        thresh = float(self.lineEditThresh.text())
+
+        nb_sous_ech_iter = int(self.lineEditIterStep.text())
+        nb_sous_ech_space = int(self.lineEditSpaceStep.text())
+        nb_sous_ech_time = int(self.lineEditTimeStep.text())
+
+        quantiles = self.lineEditQuantiles.text()
+
+        params = [nb_iter, nb_chains, delta, ncr, c, cstar, moins10logKmin, moins10logKmax, moins10logKsigma, nmin, nmax, nsigma, lambda_s_min, lambda_s_max, lambda_s_sigma, rhos_cs_min, rhos_cs_max, rhos_cs_sigma,remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time, quantiles]
+
+        self.compute.save_params_MCMC(params, nb_cells)
+
 
     def activerDesactiverModeSombre(self, state):
         if state:

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -1,5 +1,5 @@
 from PyQt5 import QtWidgets, uic
-from math import log10
+import numpy as np
 from PyQt5.QtWidgets import QTableWidgetItem
 from PyQt5.QtSql import QSqlQuery
 
@@ -20,6 +20,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         QtWidgets.QDialog.__init__(self)
         self.setupUi(self)
 
+        self.defaultParamValues = [12.0, 0.15, 3.4, 5000000.0]
         self.interaction_occurred = False
         self.maxdepth = maxdepth
         self.layers = spointcoordinator.layers_depths()
@@ -136,13 +137,13 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         """
         Set the default values in the tables for both the direct model and the MCMC
         """
-        #Direct model
+        #Direct model (1 layer)
         self.spinBoxNLayersDirect.setValue(1)
         self.tableWidget.setRowCount(1)
 
-        self.input.append([12, 0.15, 3.4, 5000000])
+        self.input = [self.defaultParamValues]
 
-        self.tableWidget.setVerticalHeaderItem(0, QTableWidgetItem(f"Layer {1}"))
+        self.tableWidget.setVerticalHeaderItem(0, QTableWidgetItem(f"Layer 1"))
         layerBottom = self.maxdepth
         self.tableWidget.setItem(0, 0, QTableWidgetItem(str(layerBottom)))
         self.tableWidget.setItem(0, 1, QTableWidgetItem(str(self.input[0][0])))
@@ -193,19 +194,17 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         if len(self.input) < nb_layers:
     
             for _ in range(nb_layers - len(self.input)):
-                self.input.append([12, 0.15, 3.4, 5000000]) #TODO : factorize default values
+                self.input.append(self.defaultParamValues)
 
         elif len(self.input) > nb_layers:
     
             for _ in range(len(self.input) - nb_layers):
                 self.input.pop()
 
-
+        layerBottoms = np.linspace(0, self.maxdepth, nb_layers+1)[1:nb_layers+1]
         for i in range(nb_layers):
             self.tableWidget.setVerticalHeaderItem(i, QTableWidgetItem(f"Layer {i+1}")) 
-            layerBottom = int((self.maxdepth/nb_layers))
-
-            self.tableWidget.setItem(i, 0, QTableWidgetItem(str(layerBottom*(i+1))))
+            self.tableWidget.setItem(i, 0, QTableWidgetItem(str(round(layerBottoms[i],3)))) # Round to 1 mm
             self.tableWidget.setItem(i, 1, QTableWidgetItem(str(self.input[i][0])))
             self.tableWidget.setItem(i, 2, QTableWidgetItem(str(self.input[i][1])))
             self.tableWidget.setItem(i, 3, QTableWidgetItem(str(self.input[i][2])))

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -21,9 +21,9 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.setupUi(self)
 
         self.interaction_occurred = False
-        self.maxdepth = maxdepth * 100
+        self.maxdepth = maxdepth
         self.layers = spointcoordinator.layers_depths()
-        self.params =[] 
+        self.params = [] 
         for layer in self.layers:
             self.params.append(spointcoordinator.get_params_model(layer))
         self.input = []
@@ -64,15 +64,13 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.spinBoxNLayersDirect.setValue(len(self.layers))
         self.tableWidget.setRowCount(len(self.input))
 
-        layerBottom = int((self.maxdepth))
-
         for i in range(len(self.input)):
             self.tableWidget.setVerticalHeaderItem(i, QTableWidgetItem(f"Layer {i+1}"))
             self.tableWidget.setItem(i, 0, QTableWidgetItem(str(self.layers[i])))
             self.tableWidget.setItem(i, 1, QTableWidgetItem(str(self.input[i][0])))
             self.tableWidget.setItem(i, 2, QTableWidgetItem(str(self.input[i][1])))
             self.tableWidget.setItem(i, 3, QTableWidgetItem(str(self.input[i][2])))
-            # self.tableWidget.setItem(i, 4, QTableWidgetItem('{:.2e}'.format(self.input[i][3])))
+            self.tableWidget.setItem(i, 4, QTableWidgetItem(str(self.input[i][3])))
 
         #MCMC
         self.lineEditChains.setText("10")
@@ -117,20 +115,20 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         if self.interaction_occurred:
             nb_layers = self.spinBoxNLayersDirect.value()
             depths = []
-            log10permeability = []
+            permeability = []
             porosity = [] 
             thermconduct = []
             thermcap = []
 
             for i in range (nb_layers):
-                log10permeability.append(-log10(abs(float(self.tableWidget.item(i, 1).text())))) #Apply -log10 to the permeability values
+                depths.append(float(self.tableWidget.item(i, 0).text()))
+                permeability.append(float(self.tableWidget.item(i, 1).text()))
                 porosity.append(float(self.tableWidget.item(i, 2).text()))
                 thermconduct.append(float(self.tableWidget.item(i, 3).text()))
                 thermcap.append(float(self.tableWidget.item(i, 4).text()))
-                depths.append(float(self.tableWidget.item(i, 0).text())/100) #Convert the depths back to m.
 
             layers = [f"Layer {i+1}" for i in range(nb_layers)]
-            params = list(zip(layers, depths, log10permeability, porosity, thermconduct, thermcap))
+            params = list(zip(layers, depths, permeability, porosity, thermconduct, thermcap))
 
             self.compute.save_layers_and_params(params)
         
@@ -142,11 +140,11 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.spinBoxNLayersDirect.setValue(1)
         self.tableWidget.setRowCount(1)
 
-        self.input.append([1e-12, 0.15, 3.4, 5e6])
+        self.input.append([12, 0.15, 3.4, 5000000])
 
         self.tableWidget.setVerticalHeaderItem(0, QTableWidgetItem(f"Layer {1}"))
-        layerBottom = int((self.maxdepth))
-        self.tableWidget.setItem(0, 0, QTableWidgetItem(str(layerBottom))) #In cm
+        layerBottom = self.maxdepth
+        self.tableWidget.setItem(0, 0, QTableWidgetItem(str(layerBottom)))
         self.tableWidget.setItem(0, 1, QTableWidgetItem(str(self.input[0][0])))
         self.tableWidget.setItem(0, 2, QTableWidgetItem(str(self.input[0][1])))
         self.tableWidget.setItem(0, 3, QTableWidgetItem(str(self.input[0][2])))
@@ -195,7 +193,8 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         if len(self.input) < nb_layers:
     
             for _ in range(nb_layers - len(self.input)):
-                self.input.append([ 1e-12, 0.15, 3.4, 5e6])
+                self.input.append([12, 0.15, 3.4, 5000000]) #TODO : factorize default values
+
         elif len(self.input) > nb_layers:
     
             for _ in range(len(self.input) - nb_layers):
@@ -206,7 +205,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
             self.tableWidget.setVerticalHeaderItem(i, QTableWidgetItem(f"Layer {i+1}")) 
             layerBottom = int((self.maxdepth/nb_layers))
 
-            self.tableWidget.setItem(i, 0, QTableWidgetItem(str(layerBottom*(i+1)))) #In cm
+            self.tableWidget.setItem(i, 0, QTableWidgetItem(str(layerBottom*(i+1))))
             self.tableWidget.setItem(i, 1, QTableWidgetItem(str(self.input[i][0])))
             self.tableWidget.setItem(i, 2, QTableWidgetItem(str(self.input[i][1])))
             self.tableWidget.setItem(i, 3, QTableWidgetItem(str(self.input[i][2])))
@@ -240,19 +239,19 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         nb_cells = self.spinBoxNCellsDirect.value()
         nb_layers = self.spinBoxNLayersDirect.value()
         depths = []
-        log10permeability = []
+        permeability = []
         porosity = []
         thermconduct = []
         thermcap = []
 
         for i in range (nb_layers):
-            log10permeability.append(-log10(abs(float(self.tableWidget.item(i, 1).text())))) #Apply -log10 to the permeability values
+            depths.append(float(self.tableWidget.item(i, 0).text()))
+            permeability.append(float(self.tableWidget.item(i, 1).text()))
             porosity.append(float(self.tableWidget.item(i, 2).text()))
             thermconduct.append(float(self.tableWidget.item(i, 3).text()))
             thermcap.append(float(self.tableWidget.item(i, 4).text()))
-            depths.append(float(self.tableWidget.item(i, 0).text())/100) #Convert the depths back to m.
         layers = [f"Layer {i+1}" for i in range(nb_layers)]
-        return list(zip(layers, depths, log10permeability, porosity, thermconduct, thermcap)), nb_cells
+        return list(zip(layers, depths, permeability, porosity, thermconduct, thermcap)), nb_cells
 
     def getInputMCMC(self):
         """
@@ -273,7 +272,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         nb_sous_ech_space = int(self.lineEditSpaceStep.text())
         nb_sous_ech_time = int(self.lineEditTimeStep.text())
 
-        #The user's input is not a permeability but a -log10(permeability)
+        # The user's input is not a permeability but a -log10(permeability)
         moins10logKmin = float(self.lineEditKMin.text())
         moins10logKmax = float(self.lineEditKMax.text())
         moins10logKsigma = float(self.lineEditmoinslog10IntrinKSigma.text())
@@ -299,7 +298,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         nb_layers = self.spinBoxNLayersDirect.value()
         depths = []
         for i in range (nb_layers):
-            depths.append(float(self.tableWidget.item(i, 0).text())/100)
+            depths.append(float(self.tableWidget.item(i, 0).text()))
         layers = [f"Layer {i+1}" for i in range(nb_layers)]
 
         all_priors = []

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -20,8 +20,9 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         QtWidgets.QDialog.__init__(self)
         self.setupUi(self)
 
+        self.activerDesactiverModeSombre(statusNightMode)
+
         self.defaultParamValues = [12.0, 0.15, 3.4, 5000000.0]
-        self.interaction_occurred = False
         self.maxdepth = maxdepth
         self.layers = spointcoordinator.layers_depths()
         self.params = [] 
@@ -47,7 +48,6 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.spinBoxNLayersDirect.valueChanged.connect(self.updateNBLayers)
         self.pushButtonRestoreDefault.clicked.connect(self.setDefaultValues)
         self.pushButtonRun.clicked.connect(self.run)
-        self.closeEvent = self.handleCloseEvent
 
         self.groupBoxMCMC.setChecked(False)
 
@@ -113,25 +113,25 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         """
         Save the layers and the last parameters in the database.
         """
-        if self.interaction_occurred:
-            nb_layers = self.spinBoxNLayersDirect.value()
-            depths = []
-            permeability = []
-            porosity = [] 
-            thermconduct = []
-            thermcap = []
+        nb_cells = self.spinBoxNCellsDirect.value()
+        nb_layers = self.spinBoxNLayersDirect.value()
+        depths = []
+        permeability = []
+        porosity = [] 
+        thermconduct = []
+        thermcap = []
 
-            for i in range (nb_layers):
-                depths.append(float(self.tableWidget.item(i, 0).text()))
-                permeability.append(float(self.tableWidget.item(i, 1).text()))
-                porosity.append(float(self.tableWidget.item(i, 2).text()))
-                thermconduct.append(float(self.tableWidget.item(i, 3).text()))
-                thermcap.append(float(self.tableWidget.item(i, 4).text()))
+        for i in range (nb_layers):
+            depths.append(float(self.tableWidget.item(i, 0).text()))
+            permeability.append(float(self.tableWidget.item(i, 1).text()))
+            porosity.append(float(self.tableWidget.item(i, 2).text()))
+            thermconduct.append(float(self.tableWidget.item(i, 3).text()))
+            thermcap.append(float(self.tableWidget.item(i, 4).text()))
 
-            layers = [f"Layer {i+1}" for i in range(nb_layers)]
-            params = list(zip(layers, depths, permeability, porosity, thermconduct, thermcap))
+        layers = [f"Layer {i+1}" for i in range(nb_layers)]
+        params = list(zip(layers, depths, permeability, porosity, thermconduct, thermcap))
 
-            self.compute.save_layers_and_params(params)
+        self.compute.save_layers_and_params(params, nb_cells)
         
     def setDefaultValues(self):
         """
@@ -210,20 +210,11 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
             self.tableWidget.setItem(i, 3, QTableWidgetItem(str(self.input[i][2])))
             self.tableWidget.setItem(i, 4, QTableWidgetItem(str(self.input[i][3])))
 
-        self.SaveInput()
-
     def run(self):
         """
         This function is called when the user presses the "Run" button: it corresponds to the "Accept" button.
         """
-        self.interaction_occurred = True
         super().accept()
-    
-    
-    def handleCloseEvent(self, event):
-        # La fenêtre est en train de se fermer, sauvegardez les données
-        self.SaveInput()
-        event.accept()
 
     def computationIsMCMC(self):
         """
@@ -313,7 +304,7 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
 
     def activerDesactiverModeSombre(self, state):
         if state:
-            self.setStyleSheet("background-color: rgb(50, 50, 50); color: rgb(255, 255, 255)")
+            self.setStyleSheet("background-color: rgb(50, 50, 50); color: rgb(255, 255, 255);")
             self.tableWidget.horizontalHeader().setStyleSheet("QHeaderView::section { background-color: #232326; color: white; }")
             self.tableWidget.verticalHeader().setStyleSheet("QHeaderView::section { background-color: #232326; color: white; }")
         else:

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -25,20 +25,18 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.layers = spointcoordinator.layers_depths()
         self.params =[] 
         for layer in self.layers:
-            self.params = spointcoordinator.get_params_model(layer)
+            self.params.append(spointcoordinator.get_params_model(layer))
         self.input = []
         num_rows = len(self.layers)
-        num_cols = 5
+        num_cols = 5 # Layer depth + 4 parameters
         self.compute = compute
 
-        for row in range(num_rows -1):
-            self.input.append([])
-            for col in range(num_cols):
-                valeur = self.params.index(row, col).data()
-                self.input[row].append(valeur)
-                
-
-        
+        if self.params:
+            for row in range(num_rows):
+                self.input.append([])
+                for col in range(num_cols):
+                    valeur = self.params[row].index(0, col).data()
+                    self.input[row].append(valeur)
 
         #Prevent the user from writing something in the spin box.
         self.spinBoxNLayersDirect.lineEdit().setReadOnly(True)

--- a/Molonaviz/src/molonaviz/frontend/dialogCompute.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogCompute.py
@@ -84,10 +84,11 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
     def InitValuesMCMC(self):
 
         #MCMC
+        # Same order than SPointCoordinator build_params_MCMC_query
         self.lineEditMaxIterMCMC.setText(str(self.inputMCMC[0]))
+        self.lineEditDelta.setText(str(self.inputMCMC[1]))
 
-        self.lineEditChains.setText(str(self.inputMCMC[1]))
-        self.lineEditDelta.setText(str(self.inputMCMC[2]))
+        self.lineEditChains.setText(str(self.inputMCMC[2]))
         self.lineEditncr.setText(str(self.inputMCMC[3]))
         self.lineEditc.setText(str(self.inputMCMC[4]))
         self.lineEditcstar.setText(str(self.inputMCMC[5]))
@@ -118,30 +119,6 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
         self.lineEditQuantiles.setText(str(self.inputMCMC[23]))
 
 
-    def SaveInput(self):
-
-        """
-        Save the layers, the parameters and the MCMC parameters in the database.
-        """
-        nb_cells = self.spinBoxNCellsDirect.value()
-        nb_layers = self.spinBoxNLayersDirect.value()
-        depths = []
-        permeability = []
-        porosity = [] 
-        thermconduct = []
-        thermcap = []
-
-        for i in range (nb_layers):
-            depths.append(float(self.tableWidget.item(i, 0).text()))
-            permeability.append(float(self.tableWidget.item(i, 1).text()))
-            porosity.append(float(self.tableWidget.item(i, 2).text()))
-            thermconduct.append(float(self.tableWidget.item(i, 3).text()))
-            thermcap.append(float(self.tableWidget.item(i, 4).text()))
-
-        layers = [f"Layer {i+1}" for i in range(nb_layers)]
-        params = list(zip(layers, depths, permeability, porosity, thermconduct, thermcap))
-
-        self.compute.save_layers_and_params(params, nb_cells)
         
     def setDefaultValues(self):
         """
@@ -309,52 +286,9 @@ class DialogCompute(QtWidgets.QDialog, From_DialogCompute):
             all_priors.append([layers[i], depths[i], priors])
 
         quantiles = self.lineEditQuantiles.text()
-        quantiles = quantiles.split(",")
-        quantiles = tuple(quantiles)
-        quantiles = [float(quantile) for quantile in quantiles]
 
-        return nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar,  remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time
-
-    def save_input_MCMC(self):
-        nb_cells = self.spinBoxNCellsDirect.value()
-
-        nb_iter = int(self.lineEditMaxIterMCMC.text())
-        nb_chains = int(self.lineEditChains.text())
-        delta = float(self.lineEditDelta.text())
-        ncr = float(self.lineEditncr.text())
-        c = float(self.lineEditc.text())
-        cstar = float(self.lineEditcstar.text())
-
-        #The user's input (in MCMC panel) is not a permeability but a -log10(permeability)
-        moins10logKmin = float(self.lineEditKMin.text())
-        moins10logKmax = float(self.lineEditKMax.text())
-        moins10logKsigma = float(self.lineEditmoinslog10IntrinKSigma.text())
-
-        nmin = float(self.lineEditPorosityMin.text())
-        nmax = float(self.lineEditPorosityMax.text())
-        nsigma = float(self.lineEditPorositySigma.text())
-
-        lambda_s_min = float(self.lineEditThermalConductivityMin.text())
-        lambda_s_max = float(self.lineEditThermalConductivityMax.text())
-        lambda_s_sigma = float(self.lineEditThermalConductivitySigma.text())
-
-        rhos_cs_min = float(self.lineEditThermalCapacityMin.text())
-        rhos_cs_max = float(self.lineEditThermalCapacityMax.text())
-        rhos_cs_sigma = float(self.lineEditThermalCapacitySigma.text())
-
-        remanence = float(self.lineEditPersi.text())
-        thresh = float(self.lineEditThresh.text())
-
-        nb_sous_ech_iter = int(self.lineEditIterStep.text())
-        nb_sous_ech_space = int(self.lineEditSpaceStep.text())
-        nb_sous_ech_time = int(self.lineEditTimeStep.text())
-
-        quantiles = self.lineEditQuantiles.text()
-
-        params = [nb_iter, nb_chains, delta, ncr, c, cstar, moins10logKmin, moins10logKmax, moins10logKsigma, nmin, nmax, nsigma, lambda_s_min, lambda_s_max, lambda_s_sigma, rhos_cs_min, rhos_cs_max, rhos_cs_sigma,remanence, thresh, nb_sous_ech_iter, nb_sous_ech_space, nb_sous_ech_time, quantiles]
-
-        self.compute.save_params_MCMC(params, nb_cells)
-
+        # Warning: order must be the same than ColumnMCMCRunner constructor (otherwise use a dictionary)
+        return [nb_iter, all_priors, nb_cells, quantiles, nb_chains, delta, ncr, c, cstar, remanence, nb_sous_ech_iter, nb_sous_ech_time, nb_sous_ech_space, thresh]
 
     def activerDesactiverModeSombre(self, state):
         if state:

--- a/Molonaviz/src/molonaviz/frontend/dialogsCleanup.py
+++ b/Molonaviz/src/molonaviz/frontend/dialogsCleanup.py
@@ -73,9 +73,7 @@ class DialogCleanup(QtWidgets.QDialog, From_DialogCleanup):
         super(DialogCleanup, self).__init__()
         QtWidgets.QDialog.__init__(self)
 
-        self.statusNightmode = statusNightmode
-        if self.statusNightmode:
-            self.activerDesactiverModeSombre(self.statusNightmode)
+        self.activerDesactiverModeSombre(statusNightmode)
 
         self.setupUi(self)
         self.coordinator = coordinator
@@ -487,8 +485,6 @@ class DialogCleanup(QtWidgets.QDialog, From_DialogCleanup):
             self.setStyleSheet("background-color: rgb(50, 50, 50); color: rgb(255, 255, 255);")
         else:
             self.setStyleSheet("")  # Utilisez la feuille de style par défaut de l'application
-            cleanedData = pd.DataFrame()  # Empty Dataframe
-        return cleanedData
 
 def saveCleanedMeasures(self):
     cleanedDataSQL = self.coordinator.build_cleaned_measures(self, True)

--- a/Molonaviz/src/molonaviz/frontend/subWindow.py
+++ b/Molonaviz/src/molonaviz/frontend/subWindow.py
@@ -10,7 +10,6 @@ class SubWindow(QtWidgets.QMdiSubWindow):
         super(SubWindow, self).__init__()
         QtWidgets.QMdiSubWindow.__init__(self)  
 
-        modesombre = modesombre
         self.activerDesactiverModeSombre(modesombre)
         
         wdg.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)  # Fixe la taille du contenu
@@ -44,7 +43,6 @@ class SubWindow(QtWidgets.QMdiSubWindow):
     def activerDesactiverModeSombre(self, state):
         if state:
             self.setStyleSheet("background-color: rgb(50, 50, 50); color: rgb(255, 255, 255)")
-        
         else:
             self.setStyleSheet("")  # Utilisez la feuille de style par défaut de l'application
 

--- a/Molonaviz/src/molonaviz/frontend/ui/dialogCompute.ui
+++ b/Molonaviz/src/molonaviz/frontend/ui/dialogCompute.ui
@@ -179,12 +179,12 @@
      </row>
      <column>
       <property name="text">
-       <string>Layer bottom depth (cm)</string>
+       <string>Layer bottom depth (m)</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Permeability (m/s)</string>
+       <string>-log10(Permeability)</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
This PR should propose a version of Molonaviz that is able to launch direct model and MCMC inversion on multi-layers parameters. The database is kept consistent with results shown in the plots. BestParameters table is no more used. Indeed, Parameters table is enough to store the best parameters identified by the inversion (the direct model is computed after the inversion using these best parameters).

This PR should fix the following issues: #12 and #16 