### PR TITLE
Add GitHub Actions workflows, test templates & fix pyheatmy dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: test-molonari
+
+on:
+  # Activate the workflow at each push on every branch
+  push:
+    branches:
+      - "*"
+  # Activate the workflow at each pull request on "main" branch
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-job:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        pyver: ["3.9", "3.10", "3.11", "3.12"]
+        module: ["pyheatmy", "Molonaviz"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.pyver }}
+
+    - name: Install pytest
+      run: pip install pytest
+
+    - name: Install ${{ matrix.module }}
+      run: pip install ${{ matrix.module }}/
+
+    - name: Test ${{ matrix.module }}
+      run: pytest ${{ matrix.module }}

--- a/Molonaviz/tests/test_Molonaviz.py
+++ b/Molonaviz/tests/test_Molonaviz.py
@@ -1,0 +1,5 @@
+from molonaviz import backend
+
+# fill this file with tests
+def test_Molonaviz():
+    assert True

--- a/pyheatmy/pyproject.toml
+++ b/pyheatmy/pyproject.toml
@@ -12,11 +12,14 @@ authors = [
   {name = "Youri Tchouboukoff", email = "youri.tchouboukoff@mines-paristech.fr"},
 ]
 dependencies = [
-    "numpy",
+    "matplotlib",
+    "scipy",
+    "pandas",
     "tqdm",
     "numba>=0.60",
     "psutil",
 ]
+requires-python = ">= 3.9"
 
 [project.urls]
 Homepage = "https://github.com/mathisbrdn/pyheatmy"

--- a/pyheatmy/tests/test_pyheatmy.py
+++ b/pyheatmy/tests/test_pyheatmy.py
@@ -1,0 +1,5 @@
+import pyheatmy
+
+# fill this file with tests
+def test_pyheatmy():
+    assert True


### PR DESCRIPTION
This PR integrates a GitHub Actions workflow in the Molonari project. This workflow will be tested at every push and every pull request merge in the `main` branch. The workflow uses several version of Python, 3.9 to 3.12 on the 3 main OSes (Ubuntu, macOS & Windows). It installs separately `pyheatmy` and `Molonaviz` using `pip install` and launch tests.

This PR also includes empty test files for `pyheatmy` and `Molonaviz`. Currently, the only thing tested is the import of the modules. 

This helped finding a few issues in `pyheatmy` dependencies: `matplotlib`, `scipy` and `pandas` were missing and due to the constraint on `numba`, Python >= 3.9 is required. The corresponding `pyproject.toml` has been updated.

This PR should at least give some help w.r.t #60 and is a stepping stone for #53.

Pierre